### PR TITLE
Vanilla-docs-theme doesn't need margin under header

### DIFF
--- a/scss/_patterns_navigation.scss
+++ b/scss/_patterns_navigation.scss
@@ -12,7 +12,7 @@
     color: $color-dark;
     line-height: 32px;
     padding: 7.5px 0;
-
+    margin-bottom: 0;
 
     &__link {
       color: $color-dark;


### PR DESCRIPTION
Remove margin-bottom below the header row that the new version of vanilla-framework added.