### PR TITLE
Add p-notifications from vanilla-framework

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -216,6 +216,45 @@
 
                         <h2 id="another-heading-two">Another heading two</h2>
                         <p>Laborum omnis doloremque soluta atque, veniam laudantium quae:</p>
+
+                        <h2>Notifications</h2>
+
+						<div class="p-notification">
+						  <p class="p-notification__response">
+							<span class="p-notification__status">Note:</span>
+							A basic notification
+						  </p>
+						</div>
+
+						<div class="p-notification">
+						  <p class="p-notification__response">
+							A basic notification without a title
+						  </p>
+						</div>
+
+						<p>A random paragraph</p>
+
+						<div class="p-notification--warning">
+						  <p class="p-notification__response">
+							<span class="p-notification__status">Warning:</span>
+							A warning
+						  </p>
+						</div>
+
+						<div class="p-notification--positive">
+						  <p class="p-notification__response">
+							<span class="p-notification__status">Positive:</span>
+							A positive message
+						  </p>
+						</div>
+
+						<div class="p-notification--negative">
+						  <p class="p-notification__response">
+							<span class="p-notification__status">Negative:</span>
+							A negative message
+						  </p>
+						</div>
+
                     </main>
             </div>
             <aside class="col-2 p-aside">

--- a/scss/_patterns_notifications.scss
+++ b/scss/_patterns_notifications.scss
@@ -1,0 +1,7 @@
+@import 'vanilla-framework/scss/global_functions';
+@import 'vanilla-framework/scss/patterns_notifications';
+
+@mixin docs-p-notifications {
+  @include vf-p-notification;
+}
+

--- a/scss/_theme.scss
+++ b/scss/_theme.scss
@@ -23,6 +23,7 @@
 @import 'patterns_aside';
 @import 'patterns_layout';
 @import 'patterns_navigation';
+@import 'patterns_notifications';
 @import 'patterns_footer';
 @import 'patterns_grid';
 @import 'patterns_social-list';
@@ -54,6 +55,7 @@
   @include docs-p-footer;
   @include docs-p-grid;
   @include docs-p-navigation;
+  @include docs-p-notifications;
   @include docs-p-sidebar-nav;
   @include docs-p-social-list;
   @include docs-p-toc;


### PR DESCRIPTION
We need to support notifications for the docs.

I've created `docs-p-notifications` which currently just includes
`vf-p-notification` directly, but could be extended in future if we have
different requirements for the docs theme.

Fixes #28.

QA
--

``` bash
npm install
node_modules/.bin/gulp build
```

Now open `demo/index.html` in your browser, and see notifications working at the bottom.