### PR TITLE
Fix the includePath on development

### DIFF
--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -34,6 +34,7 @@ gulp.task('sass:develop', function() {
 gulp.task('sass:build', function() {
   return gulp.src(sassPath)
     .pipe(sass({
+      includePaths: ['node_modules'],
       style: 'compressed',
       errLogToConsole: true,
       omitSourceMapUrl: true,

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "scripts": {
     "help": "gulp help",
-    "develop": "gulp develop",
+    "watch": "gulp develop",
     "start": "gulp jekyll",
     "test": "gulp test",
     "build": "gulp build",


### PR DESCRIPTION
## Done
Added includePath to the development and update the development command from develop to watch.

## QA
- Run `./run build` and see it works
- Run `./run watch` and see it works

## Details
Fixes https://github.com/vanilla-framework/vanilla-docs-theme/issues/46
