### PR TITLE
Auto scroll the TOC of taller than the viewport

### DIFF
--- a/scss/_patterns_aside.scss
+++ b/scss/_patterns_aside.scss
@@ -7,9 +7,12 @@
     padding: 0 1rem;
 
     @media (min-width: $breakpoint-medium) {
+      background: $color-x-light;
       border-left: 1px solid $color-mid-light;
       border-top: 0;
+      height: 100%;
       margin-top: 2rem;
+      overflow-y: auto;
       padding: 0 1rem;
     }
 


### PR DESCRIPTION
## Done
Auto scroll the TOC of taller than the viewport

## QA
- It's difficult as there isn't a true example in the theme.
- I would suggest opening https://docs.vanillaframework.io/en/settings/breakpoint-settings
- Added a bunch more menu items via the inspector
- Then apply the three styles in the inspector to see the resulting behaviour

## Details
Fixes https://github.com/vanilla-framework/vanilla-docs-theme/issues/7

